### PR TITLE
Homematic: remove dead store 'interface_id'

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -419,8 +419,11 @@ def _system_callback_handler(hass, config, src, *args):
     """System callback handler."""
     # New devices available at hub
     if src == "newDevices":
-        (interface_id, dev_descriptions) = args
-        interface = interface_id.split("-")[-1]
+        # (interface_id, dev_descriptions) = args
+        # interface = interface_id.split("-")[-1]
+
+        _interface_id, dev_descriptions = args
+        interface = _interface_id.split("-")[-1]
 
         # Device support active?
         if not hass.data[DATA_CONF][interface]["connect"]:


### PR DESCRIPTION
Fix: remove unused local `interface_id` (dead store) in `homeassistant/components/homematic/__init__.py`.

SonarCloud issue (before fix):
https://sonarcloud.io/project/issues?open=AZmRFVYz2d-msY9OjGN_&id=Mikun07_home-assistant-core-ht25