### PR TITLE
Homematic: remove dead store 'interface_id'

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -419,8 +419,6 @@ def _system_callback_handler(hass, config, src, *args):
     """System callback handler."""
     # New devices available at hub
     if src == "newDevices":
-        # (interface_id, dev_descriptions) = args
-        # interface = interface_id.split("-")[-1]
 
         _interface_id, dev_descriptions = args
         interface = _interface_id.split("-")[-1]


### PR DESCRIPTION
Fix: remove unused local `interface_id` (dead store) in `homeassistant/components/homematic/__init__.py`.

SonarCloud issue (before fix):
https://sonarcloud.io/project/issues?impactSeverities=MEDIUM&rules=python%3AS1854&severities=MAJOR&issueStatuses=OPEN%2CCONFIRMED&types=CODE_SMELL&id=Mikun07_home-assistant-core-ht25&open=AZmRFVYz2d-msY9OjGN_ 